### PR TITLE
PerlIO-via-QuotedPrint: QuotedPrint.t: Add missing exit()

### DIFF
--- a/t/QuotedPrint.t
+++ b/t/QuotedPrint.t
@@ -10,6 +10,7 @@ BEGIN {                         # Magic Perl CORE pragma
     }
     if (ord("A") == 193) {
         print "1..0 # Skip: EBCDIC\n";
+        exit 0;
     }
 }
 


### PR DESCRIPTION
 This actually could work without much work
    at t/QuotedPrint.t line 48.

          got: 'This is a t=E9st for quoted-printable text that has h=E0rdly any spe=E7ial = characters in it.
 '
     expected is 'This is a t=51st for quoted-printable text that has h=44rdly any spe=48ial = characters in it.

The code seems to work, but the test is expecting the wrong thing.